### PR TITLE
Add reset state logic to word in game contract

### DIFF
--- a/contract/contracts/WordleGame.sol
+++ b/contract/contracts/WordleGame.sol
@@ -6,16 +6,18 @@ import "./WordleToken.sol";
 contract WordleGame {
 	address public token;
 	address public admin;
-	string private WORD;
+	string private word;
 	uint256 public constant GUESS_FEE = 1 ether;
 	uint256 public constant MAX_ATTEMPTS = 5;
+	uint256 public wordId;
 
-	mapping(address => string[]) private userGuesses;
-	mapping(address => bool) private hasGuessedCorrectly;
+	mapping(uint256 => mapping(address => string[])) private userGuesses;
+	mapping(uint256 => mapping(address => bool)) private hasGuessedCorrectly;
 
 	constructor(address _token) {
 		token = _token;
 		admin = msg.sender;
+		wordId = 1;
 	}
 
 	modifier onlyAdmin() {
@@ -26,7 +28,8 @@ contract WordleGame {
 	// Function to set the word (admin only)
 	function setWord(string memory _word) external onlyAdmin {
 		require(bytes(_word).length == 5, "Word must be 5 letters long");
-		WORD = _word;
+		word = _word;
+		wordId = wordId + 1;
 	}
 
 	// Function to make a guess
@@ -37,24 +40,24 @@ contract WordleGame {
 			"Insufficient tokens!"
 		);
 		require(
-			!hasGuessedCorrectly[msg.sender],
+			!hasGuessedCorrectly[wordId][msg.sender],
 			"You have already guessed correctly!"
 		);
 		require(
-			userGuesses[msg.sender].length < MAX_ATTEMPTS,
+			userGuesses[wordId][msg.sender].length < MAX_ATTEMPTS,
 			"You have exceeded the maximum number of guesses!"
 		);
 
 		IERC20(token).transferFrom(msg.sender, address(this), GUESS_FEE);
 
 		// Update the user's guesses
-		userGuesses[msg.sender].push(userGuess);
+		userGuesses[wordId][msg.sender].push(userGuess);
 
 		// Check if the guess is correct
 		bool isCorrect = keccak256(abi.encodePacked(userGuess)) ==
-			keccak256(abi.encodePacked(WORD));
+			keccak256(abi.encodePacked(word));
 		if (isCorrect) {
-			hasGuessedCorrectly[msg.sender] = true;
+			hasGuessedCorrectly[wordId][msg.sender] = true;
 		}
 	}
 
@@ -63,25 +66,28 @@ contract WordleGame {
 		address user,
 		uint256 guessIndex
 	) public view returns (uint8[5] memory) {
-		require(guessIndex < userGuesses[user].length, "Invalid guess index!");
+		require(
+			guessIndex < userGuesses[wordId][user].length,
+			"Invalid guess index!"
+		);
 
-		string memory userGuess = userGuesses[user][guessIndex];
+		string memory userGuess = userGuesses[wordId][user][guessIndex];
 		bytes memory guessBytes = bytes(userGuess);
-		bytes memory fixedBytes = bytes(WORD);
+		bytes memory wordBytes = bytes(word);
 
 		uint8[5] memory letterStatuses;
 
-		bool[5] memory usedFixedBytes;
+		bool[5] memory usedWordBytes;
 
 		for (uint8 i = 0; i < 5; i++) {
-			if (guessBytes[i] == fixedBytes[i]) {
+			if (guessBytes[i] == wordBytes[i]) {
 				letterStatuses[i] = 2; // Using 2 for correct letters
-				usedFixedBytes[i] = true;
+				usedWordBytes[i] = true;
 			} else {
 				for (uint8 j = 0; j < 5; j++) {
-					if (!usedFixedBytes[j] && guessBytes[i] == fixedBytes[j]) {
+					if (!usedWordBytes[j] && guessBytes[i] == wordBytes[j]) {
 						letterStatuses[i] = 1; // Using 1 for misplaced letters
-						usedFixedBytes[j] = true;
+						usedWordBytes[j] = true;
 						break;
 					}
 				}
@@ -95,13 +101,13 @@ contract WordleGame {
 	function getUserGuesses(
 		address user
 	) public view returns (string[] memory) {
-		return userGuesses[user];
+		return userGuesses[wordId][user];
 	}
 
 	// Function to check if the user has guessed correctly
 	function getHasUserGuessedCorrectly(
 		address user
 	) public view returns (bool) {
-		return hasGuessedCorrectly[user];
+		return hasGuessedCorrectly[wordId][user];
 	}
 }

--- a/contract/test/WordleGame.t.sol
+++ b/contract/test/WordleGame.t.sol
@@ -44,6 +44,38 @@ contract WordleGameTest is Test {
 		);
 	}
 
+	function testChangeGameState() public {
+		vm.prank(player);
+		game.makeGuess("PLACE");
+		bool guessedCorrectly = game.getHasUserGuessedCorrectly(player);
+		assertFalse(
+			guessedCorrectly,
+			"User should not guess correctly for old word"
+		);
+
+		vm.prank(admin);
+		game.setWord("APPLE");
+
+		string[] memory previousGuesses = game.getUserGuesses(player);
+		assertEq(
+			previousGuesses.length,
+			0,
+			"Previous guesses should not persist for new word"
+		);
+		assertFalse(
+			guessedCorrectly,
+			"Previous game state should not persist for new word"
+		);
+
+		vm.prank(player);
+		game.makeGuess("APPLE");
+		guessedCorrectly = game.getHasUserGuessedCorrectly(player);
+		assertTrue(
+			guessedCorrectly,
+			"Player should guess the newly set word correctly"
+		);
+	}
+
 	function testMakeGuessWithInsufficientTokens() public {
 		vm.prank(playerWithoutTokens);
 


### PR DESCRIPTION
This PR introduces a way to track the guesses made by players and their hasAnsweredCorrectly status **for a specific word**. It makes sure that these states are correctly updated whenever the word is changed by the admin.
- Tracks all guesses made by players and associates them with a specific word.
- Updates the hasAnsweredCorrectly state and resets guesses when the admin changes the word.